### PR TITLE
Fix Octavia driver agent evaluating to false

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -397,7 +397,7 @@ kolla_enable_grafana: yes
 #kolla_enable_nova_serialconsole_proxy:
 #kolla_enable_nova_ssh:
 kolla_enable_octavia: yes
-kolla_enable_octavia_driver_agent: ovn
+#kolla_enable_octavia_driver_agent:
 #kolla_enable_opensearch:
 #kolla_enable_opensearch_dashboards:
 #kolla_enable_opensearch_dashboards_external:


### PR DESCRIPTION
`enable_octavia_driver_agent` is evaluating to false and not deploying the octavia-driver-agent container resulting in an API crash due to the missing ovn driver.