### PR TITLE
Revert to default upper constraints for Caracal

### DIFF
--- a/etc/kayobe/pip.yml
+++ b/etc/kayobe/pip.yml
@@ -3,7 +3,7 @@
 # Upper constraints file for installation of python packages.
 # Default value is
 # "https://releases.openstack.org/constraints/upper/{{ openstack_release }}"
-pip_upper_constraints_file: "https://opendev.org/openstack/requirements/raw/branch/unmaintained/2023.1/upper-constraints.txt"
+#pip_upper_constraints_file:
 
 # Use a local PyPi mirror for installing Pip packages
 #pip_local_mirror: false


### PR DESCRIPTION
This reverts commit 973b2f07ec917396cc00a8b39768bfa4de970f8c.