### PR TITLE
Configure Keystone to trust forwarded headers from HAProxy

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -89,3 +89,7 @@ keystone_identity_providers:
 keystone_identity_mappings:
 - name: "ska_mapping"
   file: "{{ kayobe_config_path }}/kolla/config/keystone/ska_identity-mappings.json"
+
+# Configure Keystone to trust forwarded headers from HAProxy as part of the ska-iam
+# protocol.
+keystone_federation_oidc_forwarded_headers: "X-Forwarded-Proto"


### PR DESCRIPTION
Configure Keystone middleware to trust forwarded header for SKA IAM.